### PR TITLE
added onHomePage state to navbar to prevent animation bug

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -17,6 +17,7 @@ import {
 import MenuIcon from '@material-ui/icons/Menu';
 import { Link } from 'react-router-dom';
 import { ReactComponent as C4CSvg } from '../svg/C4C.svg';
+import { useLocation } from 'react-router-dom';
 
 const useStyles = makeStyles({
   navBarLogo: {
@@ -58,21 +59,22 @@ const NavBar: React.FC = () => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
-  const [onHomePage, setOnHomePage] = React.useState(
-    window.location.pathname === '/'
-  );
+  const [onHomePage, setOnHomePage] = React.useState(false);
+  const location = useLocation();
+
+  React.useEffect(() => {
+    const currentPath = location.pathname;
+    setOnHomePage(currentPath === '/');
+  }, [location]);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleCloseMenu = () => {
+  const handleClose = () => {
     setAnchorEl(null);
   };
-  const handleClose = () => {
-    setOnHomePage(false);
-    handleCloseMenu();
-  };
+
   const Logo: React.FC = () => {
     if (onHomePage) {
       return (
@@ -97,9 +99,6 @@ const NavBar: React.FC = () => {
           aria-label="menu"
           component={Link}
           to="/"
-          onClick={() => {
-            setOnHomePage(true);
-          }}
         >
           <C4CSvg className={classes.navBarLogo} />
         </IconButton>
@@ -119,46 +118,22 @@ const NavBar: React.FC = () => {
                 variant="text"
                 aria-label="text primary button group"
               >
-                <Button
-                  component={Link}
-                  to="/apply"
-                  onClick={() => {
-                    setOnHomePage(false);
-                  }}
-                >
+                <Button component={Link} to="/apply">
                   <Typography variant="h6" className={classes.navlink}>
                     Apply
                   </Typography>
                 </Button>
-                <Button
-                  component={Link}
-                  to="/projects"
-                  onClick={() => {
-                    setOnHomePage(false);
-                  }}
-                >
+                <Button component={Link} to="/projects">
                   <Typography variant="h6" className={classes.navlink}>
                     Projects
                   </Typography>
                 </Button>
-                <Button
-                  component={Link}
-                  to="/jumpstart"
-                  onClick={() => {
-                    setOnHomePage(false);
-                  }}
-                >
+                <Button component={Link} to="/jumpstart">
                   <Typography variant="h6" className={classes.navlink}>
                     Jumpstart
                   </Typography>
                 </Button>
-                <Button
-                  component={Link}
-                  to="/board"
-                  onClick={() => {
-                    setOnHomePage(false);
-                  }}
-                >
+                <Button component={Link} to="/board">
                   <Typography variant="h6" className={classes.navlink}>
                     Board
                   </Typography>
@@ -183,7 +158,7 @@ const NavBar: React.FC = () => {
                 anchorEl={anchorEl}
                 keepMounted
                 open={Boolean(anchorEl)}
-                onClose={handleCloseMenu}
+                onClose={handleClose}
               >
                 <MenuItem onClick={handleClose} component={Link} to="/apply">
                   <Typography variant="body1">Apply</Typography>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -58,28 +58,60 @@ const NavBar: React.FC = () => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
+  const [onHomePage, setOnHomePage] = React.useState(
+    window.location.pathname === '/'
+  );
+
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = () => {
+  const handleCloseMenu = () => {
     setAnchorEl(null);
+  };
+  const handleClose = () => {
+    setOnHomePage(false);
+    handleCloseMenu();
+  };
+  const Logo: React.FC = () => {
+    if (onHomePage) {
+      return (
+        <IconButton
+          edge="start"
+          className={classes.logo}
+          color="inherit"
+          aria-label="menu"
+          onClick={() => {
+            setOnHomePage(true);
+          }}
+        >
+          <C4CSvg className={classes.navBarLogo} />
+        </IconButton>
+      );
+    } else {
+      return (
+        <IconButton
+          edge="start"
+          className={classes.logo}
+          color="inherit"
+          aria-label="menu"
+          component={Link}
+          to="/"
+          onClick={() => {
+            setOnHomePage(true);
+          }}
+        >
+          <C4CSvg className={classes.navBarLogo} />
+        </IconButton>
+      );
+    }
   };
 
   return (
     <AppBar position="static" color="transparent" elevation={0}>
       <Container maxWidth="md">
         <Toolbar disableGutters>
-          <IconButton
-            edge="start"
-            className={classes.logo}
-            color="inherit"
-            aria-label="menu"
-            component={Link}
-            to="/"
-          >
-            <C4CSvg className={classes.navBarLogo} />
-          </IconButton>
+          <Logo />
 
           <div className={classes.navlinks}>
             <Hidden xsDown>
@@ -87,22 +119,46 @@ const NavBar: React.FC = () => {
                 variant="text"
                 aria-label="text primary button group"
               >
-                <Button component={Link} to="/apply">
+                <Button
+                  component={Link}
+                  to="/apply"
+                  onClick={() => {
+                    setOnHomePage(false);
+                  }}
+                >
                   <Typography variant="h6" className={classes.navlink}>
                     Apply
                   </Typography>
                 </Button>
-                <Button component={Link} to="/projects">
+                <Button
+                  component={Link}
+                  to="/projects"
+                  onClick={() => {
+                    setOnHomePage(false);
+                  }}
+                >
                   <Typography variant="h6" className={classes.navlink}>
                     Projects
                   </Typography>
                 </Button>
-                <Button component={Link} to="/jumpstart">
+                <Button
+                  component={Link}
+                  to="/jumpstart"
+                  onClick={() => {
+                    setOnHomePage(false);
+                  }}
+                >
                   <Typography variant="h6" className={classes.navlink}>
                     Jumpstart
                   </Typography>
                 </Button>
-                <Button component={Link} to="/board">
+                <Button
+                  component={Link}
+                  to="/board"
+                  onClick={() => {
+                    setOnHomePage(false);
+                  }}
+                >
                   <Typography variant="h6" className={classes.navlink}>
                     Board
                   </Typography>
@@ -127,7 +183,7 @@ const NavBar: React.FC = () => {
                 anchorEl={anchorEl}
                 keepMounted
                 open={Boolean(anchorEl)}
-                onClose={handleClose}
+                onClose={handleCloseMenu}
               >
                 <MenuItem onClick={handleClose} component={Link} to="/apply">
                   <Typography variant="body1">Apply</Typography>


### PR DESCRIPTION
Basically before when react router dom reloaded the Home.tsx component something about the Typical component broke. My gut says its an interval gone wild but anywho:

I solved this by simply making navigating to the Home page from the Home page (i.e. clicking on the c4c logo on the home page) do nothing. This way the component never "reloads" onto itself.